### PR TITLE
Improve Epic chip selection logic for store switching

### DIFF
--- a/main.js
+++ b/main.js
@@ -185,8 +185,14 @@ let gfn = {
     // 2. Switch Store if needed
     if (epicChipEl) {
         console.log(`[GFN] ▶️ Found Epic chip. Ensuring it is selected...`);
-        epicChipEl.click();
-        await new Promise(r => setTimeout(r, 2000)); 
+        // get the actual chips inside the parent, in case it has multiple stores listed
+        const actualChips = Array.from(epicChipEl.querySelectorAll('mat-chip'));
+        // Find the one that actually says "Epic" to click else fallback to previous logic 
+        const exactTarget = actualChips.find(c => /epic/i.test(c.textContent)) || epicChipEl;
+        
+        // Click the true target
+        exactTarget.click();
+        await new Promise(r => setTimeout(r, 3500)); 
     } else if (moreBtn) {
         console.warn(`[GFN] ⚠ Switching store via ⋮ menu...`);
         moreBtn.click();


### PR DESCRIPTION
Add logic to address this specific scenario where the epic games picker was not being selected and telling the button is disabled 
<img width="1914" height="758" alt="Screenshot 2026-04-22 204417" src="https://github.com/user-attachments/assets/40d45691-b0f0-4111-b59e-f8fc1d9b63b0" />
